### PR TITLE
dockerfile: bump go version to 1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.2
+FROM golang:1.7.3
 
 RUN go get github.com/mitchellh/gox \
            github.com/Masterminds/glide \


### PR DESCRIPTION
This PR updates go to [version 1.7.3](https://github.com/golang/go/releases/tag/go1.7.3) on the dockerfile. 
