### PR TITLE
Add support for projectID parameter and directly setting parameters as ID

### DIFF
--- a/bin/main.go
+++ b/bin/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/andrestc/docker-machine-driver-cloudstack"
+	"github.com/atsaki/docker-machine-driver-cloudstack"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 )
 

--- a/bin/main.go
+++ b/bin/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/atsaki/docker-machine-driver-cloudstack"
+	"github.com/andrestc/docker-machine-driver-cloudstack"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 )
 

--- a/cloudstack.go
+++ b/cloudstack.go
@@ -643,7 +643,7 @@ func (d *Driver) setProject(project string) error {
 	cs := d.getClient()
 	p, _, err := cs.Project.GetProjectByName(d.Project)
 	if err != nil {
-		return fmt.Errorf("Invalid project id: %s", err)
+		return fmt.Errorf("Invalid project: %s", err)
 	}
 
 	d.ProjectID = p.Id
@@ -660,6 +660,9 @@ func (d *Driver) checkKeyPair() error {
 
 	p := cs.SSH.NewListSSHKeyPairsParams()
 	p.SetName(d.SSHKeyPair)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
 	res, err := cs.SSH.ListSSHKeyPairs(p)
 	if err != nil {
 		return err
@@ -678,6 +681,9 @@ func (d *Driver) checkInstance() error {
 	p := cs.VirtualMachine.NewListVirtualMachinesParams()
 	p.SetName(d.MachineName)
 	p.SetZoneid(d.ZoneID)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
 	res, err := cs.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
 		return err
@@ -703,6 +709,9 @@ func (d *Driver) createKeyPair() error {
 	log.Infof("Registering SSH key pair...")
 
 	p := cs.SSH.NewRegisterSSHKeyPairParams(d.SSHKeyPair, string(publicKey))
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
 	if _, err := cs.SSH.RegisterSSHKeyPair(p); err != nil {
 		return err
 	}
@@ -716,6 +725,9 @@ func (d *Driver) deleteKeyPair() error {
 	log.Infof("Deleting SSH key pair...")
 
 	p := cs.SSH.NewDeleteSSHKeyPairParams(d.SSHKeyPair)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
 	if _, err := cs.SSH.DeleteSSHKeyPair(p); err != nil {
 		return err
 	}
@@ -729,6 +741,9 @@ func (d *Driver) associatePublicIP() error {
 	p.SetZoneid(d.ZoneID)
 	if d.NetworkID != "" {
 		p.SetNetworkid(d.NetworkID)
+	}
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
 	}
 	ip, err := cs.Address.AssociateIpAddress(p)
 	if err != nil {
@@ -866,6 +881,9 @@ func (d *Driver) createSecurityGroup() error {
 	cs := d.getClient()
 
 	p1 := cs.SecurityGroup.NewCreateSecurityGroupParams(d.MachineName)
+	if d.ProjectID != "" {
+		p1.SetProjectid(d.ProjectID)
+	}
 	if _, err := cs.SecurityGroup.CreateSecurityGroup(p1); err != nil {
 		return err
 	}
@@ -877,6 +895,9 @@ func (d *Driver) createSecurityGroup() error {
 
 	p2.SetStartport(22)
 	p2.SetEndport(22)
+	if d.ProjectID != "" {
+		p2.SetProjectid(d.ProjectID)
+	}
 	if _, err := cs.SecurityGroup.AuthorizeSecurityGroupIngress(p2); err != nil {
 		return err
 	}
@@ -903,6 +924,9 @@ func (d *Driver) deleteSecurityGroup() error {
 
 	p := cs.SecurityGroup.NewDeleteSecurityGroupParams()
 	p.SetName(d.MachineName)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
 	if _, err := cs.SecurityGroup.DeleteSecurityGroup(p); err != nil {
 		return err
 	}

--- a/cloudstack.go
+++ b/cloudstack.go
@@ -291,7 +291,7 @@ func (d *Driver) GetIP() (string, error) {
 // GetState returns the state that the host is in (running, stopped, etc)
 func (d *Driver) GetState() (state.State, error) {
 	cs := d.getClient()
-	vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(d.Id)
+	vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(d.Id, d.setParams)
 	if err != nil {
 		return state.Error, err
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 58cc43e0885a5a1a288059c8fc1ba19e11ca1172ba5fe08a34061e7886bcc78a
-updated: 2016-07-06T11:25:33.550149238+09:00
+hash: 19f3000f9ce3363942a44d7b2e577ce4c96f5f61add38f69e9831bd3892c92c8
+updated: 2016-11-08T10:54:52.057507593-02:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
@@ -11,26 +11,26 @@ imports:
   version: a650a404fc3e006fea17b12615266168db79c776
   subpackages:
   - libmachine/drivers
-  - libmachine/log
-  - libmachine/mcnflag
-  - libmachine/ssh
-  - libmachine/state
   - libmachine/drivers/plugin
-  - libmachine/mcnutils
   - libmachine/drivers/plugin/localbinary
   - libmachine/drivers/rpc
+  - libmachine/log
+  - libmachine/mcnflag
+  - libmachine/mcnutils
+  - libmachine/ssh
+  - libmachine/state
   - libmachine/version
   - version
 - name: github.com/Sirupsen/logrus
   version: cdaedc68f2894175ac2b3221869685602c759e71
 - name: github.com/xanzy/go-cloudstack
-  version: 104168fa792713f5e04b76e2862779dc2ad85bcc
+  version: deca6e17c056012b540aa2d2eae3ea1e63203b85
   subpackages:
   - cloudstack
 - name: golang.org/x/crypto
   version: beef0f4390813b96e8e68fd78570396d0f4751fc
   subpackages:
+  - curve25519
   - ssh
   - ssh/terminal
-  - curve25519
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
   - package: github.com/docker/machine
     ref:     a650a404fc3e006fea17b12615266168db79c776
   - package: github.com/xanzy/go-cloudstack
-    ref:     104168fa792713f5e04b76e2862779dc2ad85bcc
+    ref:     deca6e17c056012b540aa2d2eae3ea1e63203b85
   - package: github.com/Azure/go-ansiterm
     ref:     70b2c90b260171e829f1ebd7c17f600c11858dbe
   - package: github.com/Sirupsen/logrus


### PR DESCRIPTION
This PR replaces my previously [sent PR](https://github.com/atsaki/docker-machine-driver-cloudstack/pull/2) and also implements the feature discussed in #4.

The dependency `go-cloudstack` had to be updated so we are able to send the `projectID` properly and also filter the template list by zone (needed when fetching by ID).