### PR TITLE
Setting IPAddress field

### DIFF
--- a/cloudstack.go
+++ b/cloudstack.go
@@ -345,6 +345,7 @@ func (d *Driver) Create() error {
 	d.Id = vm.Id
 
 	d.PrivateIP = vm.Nic[0].Ipaddress
+	d.IPAddress = vm.Nic[0].Ipaddress
 	if d.NetworkType == "Basic" {
 		d.PublicIP = d.PrivateIP
 	}


### PR DESCRIPTION
I noticed that this driver doesn't set a value in the IPAddress field.
This field is defined in the base driver.

I encountered a problem when bootstrapping kubernetes with rancher 2.x.
https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/#node-drivers